### PR TITLE
Remove CMAccount

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -149,7 +149,6 @@ PRODUCT_PACKAGES += \
     Eleven \
     LockClock \
     CMUpdater \
-    CMAccount \
     CyanogenSetupWizard \
     CMSettingsProvider \
     ExactCalculator


### PR DESCRIPTION
These servers are being retired. Use C-Apps (Cyanogen Acct),
Android Device Manager, or one of the many other services
that are capable of performing these tasks.

Change-Id: Ifc20768f24d3a5f9a7510b98c5e7d563fc703382
