### PR TITLE
sepolicy: Set the context for fsck.exfat/ntfs to fsck_exec

### DIFF
--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -45,3 +45,7 @@
 /sys/devices/virtual/graphics/fb0/cabc          u:object_r:livedisplay_sysfs:s0
 /sys/devices/virtual/graphics/fb0/rgb           u:object_r:livedisplay_sysfs:s0
 /sys/devices/virtual/graphics/fb0/sre           u:object_r:livedisplay_sysfs:s0
+
+# fsck
+/system/bin/fsck\.ntfs                          u:object_r:fsck_exec:s0
+/system/bin/fsck\.exfat                         u:object_r:fsck_exec:s0


### PR DESCRIPTION
This matches the policy for fsck.f2fs, although it still needs to run
as fsck_untrusted for public volumes

Change-Id: Ia04e7f8902e53a9926a87f0c99e603611cc39c5d
